### PR TITLE
[Ci] add testing and cypress e2e testing on gh actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+on: [push]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+      - name: Unit Tests
+        run: yarn test --watchAll=false
+      - name: E2E Tests
+        uses: cypress-io/github-action@v3.0.3
+        with:
+          start: yarn start
+          wait-on: 'http://localhost:3000'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,16 +10,16 @@ jobs:
     # container: cypress/included:3.8.3
     steps:
       - uses: actions/checkout@v3
-      # - name: Install Dependencies
-      #   run: cd ./apps/opinion-ate/ && yarn install --frozen-lockfile
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v2.0.1
-        with:
-          version: 6
-          # Only install what we need to run the client in-action and tests against it
-          # format:    `--filter <packagename>...`
-          run_install: |
-            - args: [--filter apps/opinion-ate... --filter cypress-tests...]
+      - name: Install Dependencies
+        run: cd ./apps/opinion-ate/ && yarn install --frozen-lockfile
+      # - name: Set up pnpm
+      #   uses: pnpm/action-setup@v2.0.1
+      #   with:
+      #     version: 6
+      #     # Only install what we need to run the client in-action and tests against it
+      #     # format:    `--filter <packagename>...`
+      #     run_install: |
+      #       - args: [--filter apps/opinion-ate... --filter cypress-tests...]
       - name: Unit Tests
         run: cd ./apps/opinion-ate/ && yarn test --watchAll=false
       - name: E2E Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         # with:
         #   # just perform install
         #   runTests: false
-      - run: yarn lint
+      # - run: yarn lint
       - name: Unit Tests
         run: yarn test --watchAll=false
         working-directory: apps/opinion-ate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies
-        working-directory: apps/opinion-ate
         run: yarn install --frozen-lockfile
-        with:
-          # just perform install
-          runTests: false
+        working-directory: apps/opinion-ate
+        # with:
+        #   # just perform install
+        #   runTests: false
       - run: yarn lint
       - name: Unit Tests
-        working-directory: apps/opinion-ate
         run: yarn test --watchAll=false
+        working-directory: apps/opinion-ate
       - name: E2E Tests
         uses: cypress-io/github-action@v3.0.3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,6 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
         working-directory: apps/opinion-ate
-        # with:
-        #   # just perform install
-        #   runTests: false
-      # - run: yarn lint
       - name: Unit Tests
         run: yarn test --watchAll=false
         working-directory: apps/opinion-ate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        run: cd ./apps/opinion-ate/ && yarn install --frozen-lockfile
       - name: Unit Tests
-        run: yarn test --watchAll=false
+        run: cd ./apps/opinion-ate/ && yarn test --watchAll=false
       - name: E2E Tests
         uses: cypress-io/github-action@v3.0.3
         with:
-          start: yarn start
+          start: cd ./apps/opinion-ate/ && yarn start
           wait-on: 'http://localhost:3000'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,32 +1,27 @@
 name: Test
 on: [push]
-
+# [reference: cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo)
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    # # Docker image with Cypress pre-installed
-    # # https://github.com/cypress-io/cypress-docker-images/tree/master/included
-    # container: cypress/included:3.8.3
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies
-        run: cd ./apps/opinion-ate/ && yarn install --frozen-lockfile
-      # - name: Set up pnpm
-      #   uses: pnpm/action-setup@v2.0.1
-      #   with:
-      #     version: 6
-      #     # Only install what we need to run the client in-action and tests against it
-      #     # format:    `--filter <packagename>...`
-      #     run_install: |
-      #       - args: [--filter apps/opinion-ate... --filter cypress-tests...]
+        working-directory: apps/opinion-ate
+        run: yarn install --frozen-lockfile
+        with:
+          # just perform install
+          runTests: false
+      - run: yarn lint
       - name: Unit Tests
-        run: cd ./apps/opinion-ate/ && yarn test --watchAll=false
+        working-directory: apps/opinion-ate
+        run: yarn test --watchAll=false
       - name: E2E Tests
         uses: cypress-io/github-action@v3.0.3
         with:
           # we have already installed all dependencies above
           install: false
-          # command: pnpm --dir cypress/ cypress:ci
-          start: cd ./apps/opinion-ate/ && yarn start
+          working-directory: apps/opinion-ate
+          start: yarn start
           wait-on: 'http://localhost:3000'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,15 +4,29 @@ on: [push]
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    # # Docker image with Cypress pre-installed
+    # # https://github.com/cypress-io/cypress-docker-images/tree/master/included
+    # container: cypress/included:3.8.3
     steps:
       - uses: actions/checkout@v3
-      - name: Install Dependencies
-        run: cd ./apps/opinion-ate/ && yarn install --frozen-lockfile
+      # - name: Install Dependencies
+      #   run: cd ./apps/opinion-ate/ && yarn install --frozen-lockfile
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6
+          # Only install what we need to run the client in-action and tests against it
+          # format:    `--filter <packagename>...`
+          run_install: |
+            - args: [--filter apps/opinion-ate... --filter cypress-tests...]
       - name: Unit Tests
         run: cd ./apps/opinion-ate/ && yarn test --watchAll=false
       - name: E2E Tests
         uses: cypress-io/github-action@v3.0.3
         with:
+          # we have already installed all dependencies above
+          install: false
+          command: pnpm --dir cypress/ cypress:ci
           start: cd ./apps/opinion-ate/ && yarn start
           wait-on: 'http://localhost:3000'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           # we have already installed all dependencies above
           install: false
-          command: pnpm --dir cypress/ cypress:ci
+          # command: pnpm --dir cypress/ cypress:ci
           start: cd ./apps/opinion-ate/ && yarn start
           wait-on: 'http://localhost:3000'

--- a/apps/opinion-ate/cypress/fixtures/example.json
+++ b/apps/opinion-ate/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/apps/opinion-ate/cypress/plugins/index.js
+++ b/apps/opinion-ate/cypress/plugins/index.js
@@ -1,0 +1,22 @@
+/// <reference types="cypress" />
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+/**
+ * @type {Cypress.PluginConfig}
+ */
+// eslint-disable-next-line no-unused-vars
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+}

--- a/apps/opinion-ate/cypress/support/commands.js
+++ b/apps/opinion-ate/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })

--- a/apps/opinion-ate/cypress/support/index.js
+++ b/apps/opinion-ate/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')


### PR DESCRIPTION
- I'm trying to use mono-repo in Github, and the GitHub CI is not working as expected  
- Then I found an example,  [cypress-gh-action-monorepo](https://github.com/bahmutov/cypress-gh-action-monorepo) to show to setup cypress in GitHub mono-repo  
	- file: .github/workflows/test.yml
	- The [action](https://github.com/mpragnarok/learning/runs/8265317426?check_suite_focus=true) is working as expected